### PR TITLE
Add rubocop to gemfile, rename obsolete cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,21 +1,9 @@
 AllCops:
-  TargetRubyVersion: 2.4.5
+  TargetRubyVersion: 2.6
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
   UseCache: false
-Rails:
-  Enabled: false
-Rails/UnknownEnv:
-  Environments:
-    - beta
-    - development
-    - ephemeral
-    - production
-    - qa
-    - sandbox
-    - simulator
-    - test
 Style/DateTime:
   Enabled: true
 Style/AsciiComments:
@@ -71,11 +59,11 @@ Naming/PredicateName:
   - is_
   - has_
   - have_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
   Exclude:
   - spec/**/*
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   # Parameter names may be equal to or greater than this value
   MinNameLength: 3
   AllowNamesEndingInNumbers: true
@@ -256,7 +244,7 @@ Style/WhenThen:
 Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
   Enabled: true
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false
@@ -269,10 +257,6 @@ Lint/LiteralAsCondition:
 Style/Lambda:
   Description: Use the new lambda literal syntax for single-line blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
-  Enabled: false
-Rails/HttpPositionalArguments:
-  Enabled: false
-Rails/SkipsModelValidations:
   Enabled: false
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in address_composer.gemspec
 gemspec
+
+gem "rubocop", "~> 1.50", require: false # Rubocop >= 1.51 drops support for ruby 2.6


### PR DESCRIPTION
While working on #21, I noticed rubocop was not running locally. It was because I had a version mismatch. I updated rubocop and changed the cops that had been renamed.
I did remove the rails-related cops, since there's no rubocop-rails being loaded and no rails in this project.

Now, in this version rubocop instead complains about the new cops that are not in the config file, but I did not want to change the rubocop config itself, just make so it would run.