### PR TITLE
Add ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   rspec:
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3]
+        ruby: [2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adds [Ruby 3.4](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/) to the test matrix