### PR TITLE
Prepare for version 2.0.0 bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in address_composer.gemspec
 gemspec
-
-gem "rubocop", "~> 1.50", require: false # Rubocop >= 1.51 drops support for ruby 2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,74 @@
+PATH
+  remote: .
+  specs:
+    address_composer (2.0.0)
+      mustache
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.1)
+    fiddle (1.1.6)
+    io-console (0.8.0)
+    irb (1.6.3)
+      reline (>= 0.3.0)
+    json (2.7.6)
+    mustache (1.1.1)
+    ostruct (0.6.1)
+    parallel (1.24.0)
+    parser (3.3.7.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
+    rexml (3.4.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
+    rubocop (1.50.2)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.6.0)
+
+PLATFORMS
+  x86_64-darwin-24
+  x86_64-linux
+
+DEPENDENCIES
+  address_composer!
+  bundler
+  fiddle
+  irb
+  ostruct
+  rake
+  reline
+  rspec
+  rubocop
+
+BUNDLED WITH
+   2.4.22

--- a/address_composer.gemspec
+++ b/address_composer.gemspec
@@ -25,12 +25,14 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.6"
   gem.require_paths = ["lib"]
-
-  gem.add_runtime_dependency "mustache", ">= 1.1"
-
-  gem.add_development_dependency "bundler", ">= 2.2"
-  gem.add_development_dependency "pry", ">= 0.14"
-  gem.add_development_dependency "pry-byebug", ">= 3.8"
-  gem.add_development_dependency "rake", ">= 13.0"
-  gem.add_development_dependency "rspec", ">= 3.10"
+  gem.add_runtime_dependency "mustache"
+  
+  gem.add_development_dependency "bundler"
+  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "ostruct"
+  gem.add_development_dependency "reline"
+  gem.add_development_dependency "irb"
+  gem.add_development_dependency "fiddle"
+  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rspec"
 end

--- a/lib/address_composer/version.rb
+++ b/lib/address_composer/version.rb
@@ -1,3 +1,3 @@
 class AddressComposer
-  VERSION = "1.0.1".freeze
+  VERSION = "2.0.0".freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "bundler/setup"
 require "address_composer"
-require "pry-byebug"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
* Removes compatibility with ruby versions prior 2.6.0
* Up to date with the changes to date of address-formatting

Thanks to @renatolond and @jscheid for their contributions to this version!